### PR TITLE
Potential fix for code scanning alert no. 13: Missing rate limiting

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -509,8 +509,15 @@ app.delete('/ingresos/:id', (req, res) => {
 
 // --- RUTAS PARA OBJETIVOS ---
 
+// Limitador de tasa para la creación de objetivos (máximo 20 por hora por IP)
+const nuevoObjetivoLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hora
+  max: 20, // máximo 20 solicitudes por ventana por IP
+  message: { error: "Demasiadas solicitudes de creación de objetivos desde esta IP, por favor intente más tarde." }
+});
+
 // Crear un nuevo objetivo
-app.post('/objetivos', (req, res) => {
+app.post('/objetivos', nuevoObjetivoLimiter, (req, res) => {
   const { usuario_id, nombre, monto_meta, monto_actual = 0, fecha_limite } = req.body;
   const id = Date.now().toString();
   const completado = 0;


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/TusFinanzas/security/code-scanning/13](https://github.com/santiagourdaneta/TusFinanzas/security/code-scanning/13)

To fix the missing rate limiting for the `/objetivos` POST endpoint, we should add a rate limiting middleware to this route. The best solution is to instantiate a new rate limiter for creating nuevos objetivos, similar to the existing `ingresosLimiter` (for incomes) or reuse a reasonable configuration.

- Define a rate limiter specifically for the `/objetivos` POST endpoint. For consistency, we might restrict this route to a certain number of requests per hour per IP (e.g., 20 per hour), but the exact limit can be tuned as desired.
- Apply the new limiter as a middleware to the `app.post('/objetivos', ...)` route.
- Add the limiter definition close to the other limiter definitions for clarity.

We will update `backend/server.js` as follows:
- Add a new rate limiter const before the `app.post('/objetivos', ...)` route definition.
- Inject the new middleware into the route, so the handler has the signature `app.post('/objetivos', nuevoObjetivoLimiter, (req, res) => { ... })`.

No changes to imports or external dependencies are needed, since `express-rate-limit` is already required and used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
